### PR TITLE
Simplify and move output param where it used

### DIFF
--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -61,17 +61,4 @@ module Ai
         .with(object: object)
     end
   end
-
-  class TestOutput < T::Struct
-    const :name, String
-    const :age, Integer
-  end
-
-  sig { void }
-  def test
-    a = Agent.new(agent_name: 'test', client: Ai::Clients::Test.new)
-    r = a.generate_object(messages: [Ai.user_message('Create a person')], output_class: TestOutput)
-
-    r.object.name.age
-  end
 end

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -4,122 +4,74 @@ module Ai
   class Agent
     extend T::Sig
 
-    class Instance
-      extend T::Sig
-      extend T::Generic
+    sig { returns(String) }
+    attr_reader :agent_name
 
-      Output = type_member
+    sig { returns(Ai::Client) }
+    attr_reader :client
 
-      sig { returns(String) }
-      attr_reader :agent_name
+    sig { params(agent_name: String, client: Ai::Client).void }
+    def initialize(agent_name:, client:)
+      @agent_name = agent_name
+      @client = client
+    end
 
-      sig { returns(T.nilable(T::Class[Output])) }
-      attr_reader :output_class
+    sig do
+      params(
+        messages: T::Array[Ai::Message],
+        runtime_context: T::Hash[String, T.anything],
+        max_retries: Integer,
+        max_steps: Integer
+      ).returns(Ai::GenerateTextResult)
+    end
+    def generate_text(messages:, runtime_context: {}, max_retries: 2, max_steps: 5)
+      options = { runtime_context: runtime_context, max_retries: max_retries, max_steps: max_steps }
 
-      sig { returns(Ai::Client) }
-      attr_reader :client
-
-      sig do
-        params(
-          agent_name: String,
-          client: Ai::Client,
-          output_class: T.nilable(T::Class[Output])
-        ).void
-      end
-      def initialize(agent_name:, client:, output_class: nil)
-        @agent_name = agent_name
-        @client = client
-        @output_class = output_class
-      end
-
-      sig do
-        params(
-          messages: T::Array[Ai::Message],
-          runtime_context: T::Hash[String, T.anything],
-          max_retries: Integer,
-          max_steps: Integer
-        ).returns(Ai::GenerateTextResult)
-      end
-      def generate_text(messages:, runtime_context: {}, max_retries: 2, max_steps: 5)
-        options = {
-          runtime_context: runtime_context,
-          max_retries: max_retries,
-          max_steps: max_steps
-        }
-
-        data = client.generate(agent_name, messages: messages, options: options)
-        TypeCoerce[Ai::GenerateTextResult].new.from(data, raise_coercion_error: false)
-      end
-
-      sig do
-        params(
-          messages: T::Array[Ai::Message],
-          runtime_context: T::Hash[String, T.anything],
-          max_retries: Integer,
-          max_steps: Integer
-        ).returns(GenerateObjectResult[Output])
-      end
-      def generate_object(messages:, runtime_context: {}, max_retries: 2, max_steps: 5)
-        if output_class.nil?
-          raise "You need to provide an output class for #{agent_name} when calling generate_object"
-        end
-
-        output = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
-
-        options = {
-          runtime_context: runtime_context,
-          max_retries: max_retries,
-          max_steps: max_steps,
-          output: output
-        }
-
-        data = client.generate(agent_name, messages: messages, options: options)
-
-        object = TypeCoerce[output_class].from(data['object'])
-        TypeCoerce[GenerateObjectResult[Output]]
-          .new
-          .from(data, raise_coercion_error: false)
-          .with(object: object)
-      end
+      data = client.generate(agent_name, messages: messages, options: options)
+      TypeCoerce[Ai::GenerateTextResult].new.from(data, raise_coercion_error: false)
     end
 
     sig do
       type_parameters(:O)
         .params(
-          agent_name: String,
+          messages: T::Array[Ai::Message],
           output_class: T.all(T::Class[T.type_parameter(:O)], T::Class[T::Struct]),
-          client: Ai::Client
+          runtime_context: T::Hash[String, T.anything],
+          max_retries: Integer,
+          max_steps: Integer
         )
-        .returns(Ai::Agent::Instance[T.all(T.type_parameter(:O), T::Struct)])
+        .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
-    def self.[](agent_name, output_class, client: Ai.client)
-      Instance.new(agent_name: agent_name, output_class: output_class, client: client)
-    end
+    def generate_object(messages:, output_class:, runtime_context: {}, max_retries: 2, max_steps: 5)
+      output = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
 
-    sig do
-      params(
-        agent_name: String,
-        messages: T::Array[Ai::Message],
-        runtime_context: T::Hash[String, T.anything],
-        max_retries: Integer,
-        max_steps: Integer,
-        client: Ai::Client
-      ).returns(Ai::GenerateTextResult)
-    end
-    def self.generate_text(
-      agent_name,
-      messages:,
-      runtime_context: {},
-      max_retries: 2,
-      max_steps: 5,
-      client: Ai.client
-    )
-      Instance.new(agent_name: agent_name, client: client).generate_text(
-        messages: messages,
+      options = {
         runtime_context: runtime_context,
         max_retries: max_retries,
-        max_steps: max_steps
-      )
+        max_steps: max_steps,
+        output: output
+      }
+
+      data = client.generate(agent_name, messages: messages, options: options)
+
+      object = TypeCoerce[output_class].from(data['object'])
+      TypeCoerce[GenerateObjectResult]
+        .new
+        .from(data, raise_coercion_error: false)
+        .with(object: object)
     end
+  end
+
+  class TestOutput < T::Struct
+    const :name, String
+    const :age, Integer
+  end
+
+  sig { void }
+  def test
+    a = Agent.new(agent_name: 'test', client: Ai::Clients::Test.new)
+    r = a.generate_object(messages: [Ai.user_message('Create a person')], output_class: TestOutput)
+
+    r.object.name.age
   end
 end

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -11,7 +11,7 @@ module Ai
     attr_reader :client
 
     sig { params(agent_name: String, client: Ai::Client).void }
-    def initialize(agent_name:, client:)
+    def initialize(agent_name:, client: Ai.client)
       @agent_name = agent_name
       @client = client
     end

--- a/lib/ai/clients/test.rb
+++ b/lib/ai/clients/test.rb
@@ -12,11 +12,17 @@ module Ai
       sig { params(endpoint: String).void }
       def initialize(endpoint = Ai.config.endpoint)
         @endpoint = endpoint
+        @returned_object = T.let({}, T::Hash[String, T.untyped])
       end
 
       sig { override.returns(T::Array[String]) }
       def agent_names
         %w[test_agent another_agent custom_agent]
+      end
+
+      sig { params(output: T::Hash[String, T.untyped]).void }
+      def set_returned_object(output) # rubocop:disable Naming/AccessorMethodName
+        @returned_object = output
       end
 
       sig do
@@ -29,7 +35,7 @@ module Ai
           .returns(T::Hash[String, T.anything])
       end
       def generate(agent_name, messages:, options: {})
-        output = options[:output]
+        output = options[:output] || options[:experimental_output]
 
         # Use the first message content for testing purposes
         message_content = messages.first&.content || ''
@@ -37,61 +43,60 @@ module Ai
         if output
           # Return object generation format
           {
-            object: {
+            'object' => @returned_object,
+            'finish_reason' => 'stop',
+            'usage' => {
+              'prompt_tokens' => 0,
+              'completion_tokens' => 0,
+              'total_tokens' => 0
             },
-            finish_reason: 'stop',
-            usage: {
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0
+            'warnings' => nil,
+            'request' => {
+              'body' => nil
             },
-            warnings: nil,
-            request: {
-              body: nil
+            'response' => {
+              'id' => '123',
+              'timestamp' => Time.now,
+              'model_id' => agent_name,
+              'headers' => nil,
+              'body' => ''
             },
-            response: {
-              id: '123',
-              timestamp: Time.now,
-              model_id: agent_name,
-              headers: nil,
-              body: nil
-            },
-            logprobs: nil,
-            provider_metadata: nil,
-            experimental_provider_metadata: nil
+            'logprobs' => nil,
+            'provider_metadata' => nil,
+            'experimental_provider_metadata' => nil
           }
         else
           # Return text generation format
           {
-            text: message_content,
-            files: [],
-            reasoning: nil,
-            reasoning_details: [],
-            sources: [],
-            experimental_output: nil,
-            tool_calls: [],
-            tool_results: [],
-            finish_reason: 'stop',
-            usage: {
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0
+            'text' => message_content,
+            'files' => [],
+            'reasoning' => nil,
+            'reasoning_details' => [],
+            'sources' => [],
+            'experimental_output' => nil,
+            'tool_calls' => [],
+            'tool_results' => [],
+            'finish_reason' => 'stop',
+            'usage' => {
+              'prompt_tokens' => 0,
+              'completion_tokens' => 0,
+              'total_tokens' => 0
             },
-            warnings: nil,
-            steps: [],
-            request: {
-              body: nil
+            'warnings' => nil,
+            'steps' => [],
+            'request' => {
+              'body' => nil
             },
-            response: {
-              id: '123',
-              timestamp: Time.now,
-              model_id: agent_name,
-              headers: nil,
-              body: nil
+            'response' => {
+              'id' => '123',
+              'timestamp' => Time.now,
+              'model_id' => agent_name,
+              'headers' => nil,
+              'body' => ''
             },
-            logprobs: nil,
-            provider_metadata: nil,
-            experimental_provider_metadata: nil
+            'logprobs' => nil,
+            'provider_metadata' => nil,
+            'experimental_provider_metadata' => nil
           }
         end
       end

--- a/lib/generators/ai/templates/agent.rb.erb
+++ b/lib/generators/ai/templates/agent.rb.erb
@@ -12,39 +12,12 @@
 
 module Ai
   module Agents
-    class <%= @agent_name.classify %>
+    class <%= @agent_name.classify %> < Ai::Agent
       extend T::Sig
 
-      sig { returns(String) }
-      def self.agent_name
-        "<%= @agent_name %>"
-      end
-
-      sig do
-        type_parameters(:O)
-          .params(output_class: T.all(T::Class[T.type_parameter(:O)], T::Class[T::Struct]))
-          .returns(Ai::Agent::Instance[T.all(T.type_parameter(:O), T::Struct)])
-      end
-      def self.[](output_class)
-        Agent[agent_name, output_class]
-      end
-
-      sig do
-        params(
-          messages: T::Array[Ai::Message],
-          runtime_context: T::Hash[String, T.anything],
-          max_retries: Integer,
-          max_steps: Integer
-        ).returns(Ai::GenerateTextResult)
-      end
-      def self.generate_text(messages:, runtime_context: {}, max_retries: 2, max_steps: 5)
-        Agent.generate_text(
-          agent_name,
-          messages: messages,
-          runtime_context: runtime_context,
-          max_retries: max_retries,
-          max_steps: max_steps
-        )
+      sig { returns(T.attached_class) }
+      def self.instance
+        new(agent_name: "<%= @agent_name %>")
       end
     end
   end

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -1,13 +1,15 @@
 # typed: strict
 
 RSpec.describe Ai::Agent do
+  let(:agent) { Ai::Agent.new(agent_name:, client: client) }
+  let(:agent_name) { 'test' }
   let(:client) { Ai::Clients::Test.new }
 
   before { Ai.client = client }
 
-  describe '.generate_text' do
+  describe '#generate_text' do
     it 'can generate text with basic message' do
-      result = Ai::Agent.generate_text('test', messages: [Ai.user_message('Hello, world!')])
+      result = agent.generate_text(messages: [Ai.user_message('Hello, world!')])
       expect(result.text).to eq('Hello, world!')
       expect(result.finish_reason).to eq(:stop)
       expect(result.usage.prompt_tokens).to eq(0)
@@ -28,11 +30,7 @@ RSpec.describe Ai::Agent do
         }
       ).and_call_original
 
-      Ai::Agent.generate_text(
-        'test',
-        messages: [Ai.user_message('Hello')],
-        runtime_context: runtime_context
-      )
+      agent.generate_text(messages: [Ai.user_message('Hello')], runtime_context: runtime_context)
     end
 
     it 'passes custom max_retries and max_steps to client' do
@@ -47,21 +45,11 @@ RSpec.describe Ai::Agent do
         }
       ).and_call_original
 
-      Ai::Agent.generate_text(
-        'test',
-        messages: [Ai.user_message('Hello')],
-        max_retries: 5,
-        max_steps: 10
-      )
-    end
-
-    it 'handles different agent names' do
-      result = Ai::Agent.generate_text('custom_agent', messages: [Ai.user_message('Test')])
-      expect(result.text).to eq('Test')
+      agent.generate_text(messages: [Ai.user_message('Hello')], max_retries: 5, max_steps: 10)
     end
 
     it 'returns proper response structure' do
-      result = Ai::Agent.generate_text('test', messages: [Ai.user_message('Hello')])
+      result = agent.generate_text(messages: [Ai.user_message('Hello')])
 
       expect(result).to respond_to(:text)
       expect(result).to respond_to(:files)
@@ -79,209 +67,77 @@ RSpec.describe Ai::Agent do
     end
   end
 
-  describe 'Agent.[]' do
-    class Output < T::Struct
-      const :name, String
-      const :age, Integer
+  describe '#generate_object' do
+    subject do
+      agent.generate_object(messages: [Ai.user_message('Create person')], output_class: schema)
     end
 
-    it 'creates an agent instance with output class' do
-      agent = Ai::Agent['test_agent', Output]
-
-      expect(agent.agent_name).to eq('test_agent')
-      expect(agent.output_class).to eq(Output)
-      expect(agent.client).to eq(client)
+    let(:schema) do
+      Class.new(T::Struct) do
+        const :name, String
+        const :age, Integer
+      end
     end
 
-    it 'instantiates response as output struct' do
-      agent = Ai::Agent['test_agent', Output]
+    before { client.set_returned_object({ 'name' => 'John Doe', 'age' => 30 }) }
 
-      allow(client).to receive(:generate).and_return(
-        mock_object_response({ 'name' => 'John', 'age' => 30 })
-      )
+    it 'can generate object with valid schema' do
+      result = subject
 
-      result = agent.generate_object(messages: [Ai.user_message('Test')])
-
-      expect(result.object).to be_a(Output)
-      expect(result.object.name).to eq('John')
+      expect(result.object.name).to eq('John Doe')
       expect(result.object.age).to eq(30)
+      expect(result.finish_reason).to eq(:stop)
+      expect(result.usage.prompt_tokens).to eq(0)
+      expect(result.usage.completion_tokens).to eq(0)
+      expect(result.usage.total_tokens).to eq(0)
     end
 
-    it 'raises error when calling generate_object without output_class' do
-      agent = Ai::Agent::Instance.new(agent_name: 'test', client: client, output_class: nil)
+    it 'passes runtime_context and options to client' do
+      runtime_context = { 'user_id' => '456', 'context' => 'test' }
 
-      expect { agent.generate_object(messages: [Ai.user_message('Test')]) }.to raise_error(
-        /You need to provide an output class/
+      expect(client).to receive(:generate).with(
+        'test',
+        messages: anything,
+        options:
+          hash_including(
+            runtime_context: runtime_context,
+            max_retries: 3,
+            max_steps: 8,
+            output: anything
+          )
+      ).and_call_original
+
+      agent.generate_object(
+        messages: [Ai.user_message('Create person')],
+        output_class: schema,
+        runtime_context: runtime_context,
+        max_retries: 3,
+        max_steps: 8
       )
     end
-  end
 
-  describe 'mocked responses' do
-    context 'when client returns different text' do
-      before do
-        allow(client).to receive(:generate).and_return(
-          mock_text_response(
-            'Mocked response',
-            files: [
-              mock_file('SGVsbG8gd29ybGQ=', [72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]), # "Hello world"
-              mock_file('VGVzdCBmaWxlIDI=', [84, 101, 115, 116, 32, 102, 105, 108, 101, 32, 50]) # "Test file 2"
-            ],
-            reasoning: 'This is my reasoning',
-            reasoning_details: [{ type: 'text', text: 'First thought', signature: nil, data: nil }],
-            sources: %w[source1 source2],
-            experimental_output: {
-              custom: 'data'
-            },
-            tool_calls: [{ name: 'test_tool', args: {} }],
-            tool_results: [{ result: 'success' }],
-            finish_reason: :tool_calls,
-            warnings: ['Warning message'],
-            steps: [mock_step('Thinking step', reasoning: 'Step reasoning')],
-            request: mock_request('request body'),
-            response:
-              mock_response_metadata('mock-id-456', 'mock-model', 'response body').merge(
-                'timestamp' => Time.new(2023, 1, 1),
-                'headers' => {
-                  'Content-Type' => 'application/json'
-                }
-              ),
-            logprobs: {
-              tokens: %w[hello world]
-            },
-            provider_metadata: {
-              provider: 'test'
-            },
-            experimental_provider_metadata: {
-              experimental: true
-            }
-          )
-        )
-      end
+    it 'returns proper GenerateObjectResult structure' do
+      result = subject
 
-      it 'returns the mocked response data' do
-        result = Ai::Agent.generate_text('test', messages: [Ai.user_message('Any message')])
+      expect(result).to respond_to(:object)
+      expect(result).to respond_to(:finish_reason)
+      expect(result).to respond_to(:usage)
+      expect(result).to respond_to(:warnings)
+      expect(result).to respond_to(:request)
+      expect(result).to respond_to(:response)
+      expect(result).to respond_to(:logprobs)
+      expect(result).to respond_to(:provider_metadata)
+      expect(result).to respond_to(:experimental_provider_metadata)
 
-        expect(result.text).to eq('Mocked response')
-        expect(result.files.length).to eq(2)
-        expect(T.must(result.files.first).base64).to eq('SGVsbG8gd29ybGQ=')
-        expect(T.must(result.files.first).mime_type).to eq('text/plain')
-        expect(T.must(result.files.last).base64).to eq('VGVzdCBmaWxlIDI=')
-        expect(result.reasoning).to eq('This is my reasoning')
-        expect(result.finish_reason).to eq(:tool_calls)
-        expect(result.usage.prompt_tokens).to eq(10)
-        expect(result.usage.completion_tokens).to eq(20)
-        expect(result.usage.total_tokens).to eq(30)
-        expect(result.steps.length).to eq(1)
-        expect(T.must(result.steps.first).text).to eq('Thinking step')
-        expect(T.must(result.steps.first).step_type).to eq('initial')
-        expect(result.tool_calls).to eq([{ name: 'test_tool', args: {} }])
-        expect(result.tool_results).to eq([{ result: 'success' }])
-      end
+      expect(result.object).to be_a(schema)
     end
 
-    context 'when client simulates an error scenario' do
-      before do
-        allow(client).to receive(:generate).and_return(
-          mock_text_response(
-            'Error occurred',
-            finish_reason: :error,
-            usage: mock_usage(5, 0, 5),
-            warnings: ['Model encountered an error'],
-            response: mock_response_metadata('error-123', 'test', 'error response body')
-          )
-        )
-      end
+    context 'when LLM produces a different schema' do
+      before { client.set_returned_object({ 'last_name' => 'Bob', 'age' => '42' }) }
 
-      it 'handles error responses gracefully' do
-        result = Ai::Agent.generate_text('test', messages: [Ai.user_message('Trigger error')])
-
-        expect(result.text).to eq('Error occurred')
-        expect(result.finish_reason).to eq(:error)
-        expect(result.usage.completion_tokens).to eq(0)
-        expect(result.warnings).to eq(['Model encountered an error'])
+      it 'handles type coercion correctly' do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
-  end
-
-  private
-
-  def mock_object_response(object_data, options = {})
-    {
-      'object' => object_data,
-      'finish_reason' => options[:finish_reason] || 'stop',
-      'usage' => options[:usage] || mock_usage,
-      'warnings' => options[:warnings],
-      'request' => options[:request] || mock_request,
-      'response' =>
-        options[:response] || mock_response_metadata(options[:response_id] || 'mock-123'),
-      'logprobs' => options[:logprobs],
-      'provider_metadata' => options[:provider_metadata],
-      'experimental_provider_metadata' => options[:experimental_provider_metadata]
-    }
-  end
-
-  def mock_usage(prompt_tokens = 10, completion_tokens = 20, total_tokens = 30)
-    {
-      'prompt_tokens' => prompt_tokens,
-      'completion_tokens' => completion_tokens,
-      'total_tokens' => total_tokens
-    }
-  end
-
-  def mock_request(body = nil)
-    { 'body' => body }
-  end
-
-  def mock_response_metadata(id = 'mock-123', model = 'test', body = 'mock response body')
-    { 'id' => id, 'timestamp' => Time.now, 'model_id' => model, 'headers' => nil, 'body' => body }
-  end
-
-  def mock_text_response(text, options = {})
-    {
-      text: text,
-      files: options[:files] || [],
-      reasoning: options[:reasoning],
-      reasoning_details: options[:reasoning_details] || [],
-      sources: options[:sources] || [],
-      experimental_output: options[:experimental_output],
-      tool_calls: options[:tool_calls] || [],
-      tool_results: options[:tool_results] || [],
-      finish_reason: options[:finish_reason] || 'stop',
-      usage: options[:usage] || mock_usage,
-      warnings: options[:warnings],
-      steps: options[:steps] || [],
-      request: options[:request] || mock_request,
-      response: options[:response] || mock_response_metadata,
-      logprobs: options[:logprobs],
-      provider_metadata: options[:provider_metadata],
-      experimental_provider_metadata: options[:experimental_provider_metadata]
-    }
-  end
-
-  def mock_file(base64, uint8_array, mime_type = 'text/plain')
-    { base64: base64, uint8_array: uint8_array, mime_type: mime_type }
-  end
-
-  def mock_step(text, options = {})
-    {
-      text: text,
-      reasoning: options[:reasoning],
-      reasoning_details: options[:reasoning_details] || [],
-      files: options[:files] || [],
-      sources: options[:sources] || [],
-      tool_calls: options[:tool_calls] || [],
-      tool_results: options[:tool_results] || [],
-      finish_reason: options[:finish_reason] || 'stop',
-      usage: options[:usage] || mock_usage(1, 1, 2),
-      warnings: options[:warnings],
-      logprobs: options[:logprobs],
-      request: options[:request] || mock_request,
-      response:
-        options[:response] || mock_response_metadata('step-123', 'test', 'step response body'),
-      provider_metadata: options[:provider_metadata],
-      experimental_provider_metadata: options[:experimental_provider_metadata],
-      step_type: options[:step_type] || 'initial',
-      is_continued: options[:is_continued] || false
-    }
   end
 end


### PR DESCRIPTION
## 🚪 Why?

Simplify structure and respect type safety.
Pass output Struct parameter where it is used to allow easier logic follow

## 🔑 What?

Remove parametarization of Agent class. 
Rely on test client to do agent test instead of mocked methods.
