### PR TITLE
Properly configure the default client

### DIFF
--- a/lib/ai.rb
+++ b/lib/ai.rb
@@ -43,10 +43,7 @@ module Ai
   LogProbs = T.type_alias { T.anything }
   ProviderMetadata = T.type_alias { T.anything }
 
-  config_accessor :endpoint, :origin
-  config_accessor :client,
-                  default:
-                    Ai::Clients::Mastra.new(Ai.config.endpoint || ENV['MASTRA_LOCATION'].to_s)
+  config_accessor :origin, :client
 
   sig { params(content: String).returns(Ai::Message) }
   def self.user_message(content)
@@ -56,5 +53,20 @@ module Ai
   sig { params(content: String).returns(Ai::Message) }
   def self.system_message(content)
     Ai::Message.new(role: Ai::MessageRole::System, content: content)
+  end
+
+  sig { returns(T.nilable(Ai::Client)) }
+  def self.client
+    @client ||=
+      T.let(
+        begin
+          if ENV['MASTRA_LOCATION'].present?
+            Ai::Clients::Mastra.new(ENV.fetch('MASTRA_LOCATION'))
+          else
+            config.client
+          end
+        end,
+        T.nilable(Ai::Client)
+      )
   end
 end

--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -10,7 +10,12 @@ module Ai
       extend T::Sig
 
       sig { params(endpoint: String).void }
-      def initialize(endpoint = Ai.config.endpoint)
+      def initialize(endpoint)
+        if endpoint.blank?
+          raise Ai::Error,
+                'Mastra endpoint is not set. Please set the MASTRA_LOCATION environment variable or configure the client in the Ai.config object.'
+        end
+
         @endpoint = endpoint
       end
 

--- a/lib/generators/ai/templates/agent.rb.erb
+++ b/lib/generators/ai/templates/agent.rb.erb
@@ -17,7 +17,7 @@ module Ai
 
       sig { returns(T.attached_class) }
       def self.instance
-        new(agent_name: "<%= @agent_name %>")
+        new(agent_name: '<%= @agent_name %>')
       end
     end
   end

--- a/spec/lib/ai/ai_spec.rb
+++ b/spec/lib/ai/ai_spec.rb
@@ -8,21 +8,8 @@ RSpec.describe Ai do
   describe 'configuration' do
     after do
       # Reset configuration after each test
-      Ai.config.endpoint = nil
       Ai.config.origin = nil
-      Ai.config.client = Ai::Clients::Mastra.new
-    end
-
-    describe '.endpoint' do
-      it 'can be set and retrieved' do
-        endpoint = 'https://api.example.com'
-        Ai.config.endpoint = endpoint
-        expect(Ai.config.endpoint).to eq(endpoint)
-      end
-
-      it 'defaults to nil' do
-        expect(Ai.config.endpoint).to be_nil
-      end
+      Ai.config.client = nil
     end
 
     describe '.origin' do
@@ -30,10 +17,6 @@ RSpec.describe Ai do
         origin = 'https://app.example.com'
         Ai.config.origin = origin
         expect(Ai.config.origin).to eq(origin)
-      end
-
-      it 'defaults to nil' do
-        expect(Ai.config.origin).to be_nil
       end
     end
 
@@ -44,8 +27,12 @@ RSpec.describe Ai do
         expect(Ai.config.client).to eq(test_client)
       end
 
-      it 'defaults to Mastra client' do
-        expect(Ai.config.client).to be_a(Ai::Clients::Mastra)
+      context 'when the MASTRA_LOCATION environment variable is set' do
+        before { ENV['MASTRA_LOCATION'] = 'https://mastra_host:4111' }
+
+        it 'uses the Mastra client' do
+          expect(Ai.client).to be_a(Ai::Clients::Mastra)
+        end
       end
     end
   end

--- a/spec/lib/ai/mastra_client_spec.rb
+++ b/spec/lib/ai/mastra_client_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe Ai::Clients::Mastra do
       }
     end
 
+    context 'when the endpoint is blank' do
+      it 'raises an error' do
+        expect { described_class.new('') }.to raise_error(
+          Ai::Error,
+          'Mastra endpoint is not set. Please set the MASTRA_LOCATION environment variable or configure the client in the Ai.config object.'
+        )
+      end
+    end
+
     it 'generates text using the Mastra API' do
       VCR.use_cassette('mastra_generate_agent_text') do
         result = client.generate('marvin', messages: [Ai.user_message('Hello!')])


### PR DESCRIPTION
We only want to set the client to Mastra if the environment variable is present. Also, if the mastra client is not properly intialized we should let the user know, otherwise we can have obscure errors when doing `URI.join(endpoint, ...)`.