### PR TITLE
create helper to get test instance

### DIFF
--- a/lib/generators/ai/templates/agent.rb.erb
+++ b/lib/generators/ai/templates/agent.rb.erb
@@ -19,6 +19,11 @@ module Ai
       def self.instance
         new(agent_name: '<%= @agent_name %>')
       end
+
+      sig { returns(T.attached_class) }
+      def self.test_instance
+        new(agent_name: '<%= @agent_name %>', client: Ai::Clients::Test.new)
+      end
     end
   end
 end


### PR DESCRIPTION
## 🚪 Why?

Allow users to mock network calls

## 🔑 What?

add test_instance helper that uses Test client
