### PR TITLE
Fix Mastra client

### DIFF
--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -54,7 +54,7 @@ module Ai
       end
       def response(url:, messages:, options:)
         http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = true
+        http.use_ssl = (url.scheme == 'https')
 
         request = Net::HTTP::Post.new(url)
         request['Content-Type'] = 'text/plain;charset=UTF-8'


### PR DESCRIPTION
We should only use SSL if the endpoint is using https, otherwise we'll get SSL errors like https://factorial.sentry.io/issues/6683683880.