### PR TITLE
Feat/drop backfilling

### DIFF
--- a/lib/ai.rb
+++ b/lib/ai.rb
@@ -32,7 +32,7 @@ module Ai
   autoload :ResponseMetadata, 'ai/types/response_metadata'
   autoload :StepResult, 'ai/types/step_result'
   autoload :TelemetrySettings, 'ai/types/telemetry_settings'
-  autoload :TotalUsage, 'ai/types/total_usage'
+  autoload :Usage, 'ai/types/usage'
 
   ToolSet = T.type_alias { T::Hash[String, T.anything] }
   ToolCall = T.type_alias { T.anything }

--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -67,7 +67,14 @@ module Ai
         url = URI.join(@base_uri, "api/agents/#{agent_name}/generate")
         generated_response = response(url: url, messages: messages, options: options)
 
-        JSON.parse(generated_response.body || '').deep_transform_keys(&:underscore)
+        parsed_response =
+          JSON.parse(generated_response.body || '').deep_transform_keys(&:underscore)
+
+        if parsed_response['response'] && parsed_response['response']['messages']
+          parsed_response['response']['body'] = parsed_response['response']['messages']
+        end
+
+        parsed_response
       end
 
       sig do

--- a/lib/ai/clients/test.rb
+++ b/lib/ai/clients/test.rb
@@ -45,7 +45,7 @@ module Ai
           {
             'object' => @returned_object,
             'finish_reason' => 'stop',
-            'total_usage' => {
+            'usage' => {
               'input_tokens' => 10,
               'output_tokens' => 5,
               'total_tokens' => 15
@@ -76,7 +76,7 @@ module Ai
             'tool_calls' => [],
             'tool_results' => [],
             'finish_reason' => 'stop',
-            'total_usage' => {
+            'usage' => {
               'input_tokens' => 8,
               'output_tokens' => 3,
               'total_tokens' => 11

--- a/lib/ai/types/generate_object_result.rb
+++ b/lib/ai/types/generate_object_result.rb
@@ -11,7 +11,7 @@ module Ai
     # Why the language-model call finished (e.g. :stop, :length…)
     const :finish_reason, Ai::FinishReason
     # Usage format
-    const :total_usage, T.nilable(TotalUsage), default: nil
+    const :usage, T.nilable(Usage), default: nil
     # Provider warnings (e.g. unsupported settings)
     const :warnings, T.nilable(T::Array[CallWarning])
     # Raw request metadata (body, headers, etc.)

--- a/lib/ai/types/generate_text_result.rb
+++ b/lib/ai/types/generate_text_result.rb
@@ -12,7 +12,7 @@ module Ai
     const :tool_calls, ToolCallArray
     const :tool_results, ToolResultArray
     const :finish_reason, FinishReason
-    const :total_usage, T.nilable(TotalUsage), default: nil
+    const :usage, T.nilable(Usage), default: nil
     const :warnings, T.nilable(T::Array[CallWarning])
     const :steps, T::Array[StepResult]
     const :request, LanguageModelRequestMetadata

--- a/lib/ai/types/step_result.rb
+++ b/lib/ai/types/step_result.rb
@@ -10,7 +10,7 @@ module Ai
     const :tool_calls, ToolCallArray
     const :tool_results, ToolResultArray
     const :finish_reason, FinishReason
-    const :total_usage, T.nilable(TotalUsage), default: nil
+    const :usage, T.nilable(Usage), default: nil
     const :warnings, T.nilable(T::Array[CallWarning])
     const :logprobs, T.nilable(LogProbs)
     const :request, LanguageModelRequestMetadata

--- a/lib/ai/types/usage.rb
+++ b/lib/ai/types/usage.rb
@@ -1,7 +1,7 @@
 # typed: strict
 
 module Ai
-  class TotalUsage < T::Struct
+  class Usage < T::Struct
     const :input_tokens, Integer
     const :output_tokens, Integer
     const :total_tokens, Integer

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Ai::Agent do
       result = agent.generate_text(messages: [Ai.user_message('Hello, world!')])
       expect(result.text).to eq('Hello, world!')
       expect(result.finish_reason).to eq(:stop)
-      expect(result.total_usage.input_tokens).to eq(8)
-      expect(result.total_usage.output_tokens).to eq(3)
-      expect(result.total_usage.total_tokens).to eq(11)
+      expect(result.usage.input_tokens).to eq(8)
+      expect(result.usage.output_tokens).to eq(3)
+      expect(result.usage.total_tokens).to eq(11)
     end
 
     it 'passes runtime_context to the client' do
@@ -101,7 +101,7 @@ RSpec.describe Ai::Agent do
       expect(result).to respond_to(:files)
       expect(result).to respond_to(:reasoning)
       expect(result).to respond_to(:finish_reason)
-      expect(result).to respond_to(:total_usage)
+      expect(result).to respond_to(:usage)
       expect(result).to respond_to(:steps)
       expect(result).to respond_to(:tool_calls)
       expect(result).to respond_to(:tool_results)
@@ -133,11 +133,11 @@ RSpec.describe Ai::Agent do
       expect(result.object.name).to eq('John Doe')
       expect(result.object.age).to eq(30)
       expect(result.finish_reason).to eq(:stop)
-      expect(result.total_usage.input_tokens).to eq(10)
-      expect(result.total_usage.output_tokens).to eq(5)
-      expect(result.total_usage.total_tokens).to eq(15)
-      expect(result.total_usage.reasoning_tokens).to be_nil
-      expect(result.total_usage.cached_input_tokens).to be_nil
+      expect(result.usage.input_tokens).to eq(10)
+      expect(result.usage.output_tokens).to eq(5)
+      expect(result.usage.total_tokens).to eq(15)
+      expect(result.usage.reasoning_tokens).to be_nil
+      expect(result.usage.cached_input_tokens).to be_nil
     end
 
     it 'passes runtime_context and options to client' do
@@ -199,7 +199,7 @@ RSpec.describe Ai::Agent do
 
       expect(result).to respond_to(:object)
       expect(result).to respond_to(:finish_reason)
-      expect(result).to respond_to(:total_usage)
+      expect(result).to respond_to(:usage)
       expect(result).to respond_to(:warnings)
       expect(result).to respond_to(:request)
       expect(result).to respond_to(:response)


### PR DESCRIPTION
## 🚪 Why?

We were missing to add body transformation that we were patching in Mastra, so previous changes wouldn't be enough to go through with [this](https://github.com/factorialco/factorial-agent/pull/218/files) PR.

## 🔑 What?

Encapsulated everything in usage to follow new Mastra output format and parsed messages into body so all the monolith tests will pass, even after drop the backfilling from Mastra.