### PR TITLE
fix: use application/json Content-Type for agent generate requests

### DIFF
--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -287,7 +287,7 @@ module Ai
       end
       def response(url:, messages:, options:)
         request = Net::HTTP::Post.new(url)
-        request['Content-Type'] = 'text/plain;charset=UTF-8'
+        request['Content-Type'] = 'application/json'
         request['Origin'] = Ai.config.origin
         request['Authorization'] = "Bearer #{Ai.config.api_key}" if Ai.config.api_key.present?
 


### PR DESCRIPTION
## Problem

The `response` method in `lib/ai/clients/mastra.rb` was setting `Content-Type: text/plain;charset=UTF-8` while sending a JSON body. This caused the mastra server to not parse the request body correctly, resulting in `Argument 'messages' is required` errors.

## Root Cause

The bug was present since the first commit (`9639eff` - June 10, 2025) but only became visible when the mastra server started strictly validating Content-Type headers for body parsing.

## Fix

Changed line 290 from:
```ruby
request['Content-Type'] = 'text/plain;charset=UTF-8'
```

to:
```ruby
request['Content-Type'] = 'application/json'
```

## Testing

Tested locally with meetings chat - the `Argument 'messages' is required` error no longer occurs.