### PR TITLE
feat: delegated auth support — token forwarding and principal-based resolver

### DIFF
--- a/lib/ai.rb
+++ b/lib/ai.rb
@@ -47,7 +47,7 @@ module Ai
   LogProbs = T.type_alias { T.anything }
   ProviderMetadata = T.type_alias { T.anything }
 
-  config_accessor :origin, :client, :api_key
+  config_accessor :origin, :client, :api_key, :delegated_token_resolver
 
   sig { params(content: String).returns(Ai::Message) }
   def self.user_message(content)

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -23,7 +23,7 @@ module Ai
         max_retries: Integer,
         max_steps: Integer,
         telemetry: Ai::TelemetrySettings,
-        delegated_auth: T.nilable(T.anything)
+        delegated_auth: T.nilable(Object)
       ).returns(Ai::GenerateTextResult)
     end
     def generate_text(
@@ -55,7 +55,7 @@ module Ai
           max_retries: Integer,
           max_steps: Integer,
           telemetry: Ai::TelemetrySettings,
-          delegated_auth: T.nilable(T.anything)
+          delegated_auth: T.nilable(Object)
         )
         .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
@@ -92,7 +92,7 @@ module Ai
 
     private
 
-    sig { params(delegated_auth: T.nilable(T.anything)).returns(T.nilable(String)) }
+    sig { params(delegated_auth: T.nilable(Object)).returns(T.nilable(String)) }
     def resolve_delegated_token(delegated_auth)
       return nil if delegated_auth.nil?
 

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -22,7 +22,8 @@ module Ai
         runtime_context: T::Hash[String, T.anything],
         max_retries: Integer,
         max_steps: Integer,
-        telemetry: Ai::TelemetrySettings
+        telemetry: Ai::TelemetrySettings,
+        delegated_token: T.nilable(String)
       ).returns(Ai::GenerateTextResult)
     end
     def generate_text(
@@ -30,7 +31,8 @@ module Ai
       runtime_context: {},
       max_retries: 2,
       max_steps: 5,
-      telemetry: Ai::TelemetrySettings.new
+      telemetry: Ai::TelemetrySettings.new,
+      delegated_token: nil
     )
       options = {
         runtime_context: runtime_context,
@@ -39,7 +41,7 @@ module Ai
         telemetry: telemetry
       }
 
-      data = client.generate(agent_name, messages: messages, options: options)
+      data = client.generate(agent_name, messages: messages, options: options, delegated_token: delegated_token)
       TypeCoerce[Ai::GenerateTextResult].new.from(data, raise_coercion_error: false)
     end
 
@@ -51,7 +53,8 @@ module Ai
           runtime_context: T::Hash[String, T.anything],
           max_retries: Integer,
           max_steps: Integer,
-          telemetry: Ai::TelemetrySettings
+          telemetry: Ai::TelemetrySettings,
+          delegated_token: T.nilable(String)
         )
         .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
@@ -61,7 +64,8 @@ module Ai
       runtime_context: {},
       max_retries: 2,
       max_steps: 5,
-      telemetry: Ai::TelemetrySettings.new
+      telemetry: Ai::TelemetrySettings.new,
+      delegated_token: nil
     )
       schema = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
 
@@ -75,7 +79,7 @@ module Ai
         telemetry: telemetry
       }
 
-      data = client.generate(agent_name, messages: messages, options: options)
+      data = client.generate(agent_name, messages: messages, options: options, delegated_token: delegated_token)
 
       object = TypeCoerce[output_class].from(data['object'])
       TypeCoerce[GenerateObjectResult]

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -23,7 +23,7 @@ module Ai
         max_retries: Integer,
         max_steps: Integer,
         telemetry: Ai::TelemetrySettings,
-        delegated_token: T.nilable(String)
+        delegated_auth: T.untyped
       ).returns(Ai::GenerateTextResult)
     end
     def generate_text(
@@ -32,7 +32,7 @@ module Ai
       max_retries: 2,
       max_steps: 5,
       telemetry: Ai::TelemetrySettings.new,
-      delegated_token: nil
+      delegated_auth: nil
     )
       options = {
         runtime_context: runtime_context,
@@ -41,6 +41,7 @@ module Ai
         telemetry: telemetry
       }
 
+      delegated_token = resolve_delegated_token(delegated_auth)
       data = client.generate(agent_name, messages: messages, options: options, delegated_token: delegated_token)
       TypeCoerce[Ai::GenerateTextResult].new.from(data, raise_coercion_error: false)
     end
@@ -54,7 +55,7 @@ module Ai
           max_retries: Integer,
           max_steps: Integer,
           telemetry: Ai::TelemetrySettings,
-          delegated_token: T.nilable(String)
+          delegated_auth: T.untyped
         )
         .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
@@ -65,7 +66,7 @@ module Ai
       max_retries: 2,
       max_steps: 5,
       telemetry: Ai::TelemetrySettings.new,
-      delegated_token: nil
+      delegated_auth: nil
     )
       schema = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
 
@@ -79,6 +80,7 @@ module Ai
         telemetry: telemetry
       }
 
+      delegated_token = resolve_delegated_token(delegated_auth)
       data = client.generate(agent_name, messages: messages, options: options, delegated_token: delegated_token)
 
       object = TypeCoerce[output_class].from(data['object'])
@@ -86,6 +88,18 @@ module Ai
         .new
         .from(data, raise_coercion_error: false)
         .with(object: object)
+    end
+
+    private
+
+    sig { params(delegated_auth: T.untyped).returns(T.nilable(String)) }
+    def resolve_delegated_token(delegated_auth)
+      return nil if delegated_auth.nil?
+
+      resolver = Ai.config.delegated_token_resolver
+      raise Ai::Error, 'delegated_token_resolver is not configured. Set Ai.delegated_token_resolver in your initializer.' if resolver.nil?
+
+      resolver.call(delegated_auth)
     end
   end
 end

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -23,7 +23,7 @@ module Ai
         max_retries: Integer,
         max_steps: Integer,
         telemetry: Ai::TelemetrySettings,
-        delegated_auth: T.untyped
+        delegated_auth: T.nilable(T.anything)
       ).returns(Ai::GenerateTextResult)
     end
     def generate_text(
@@ -55,7 +55,7 @@ module Ai
           max_retries: Integer,
           max_steps: Integer,
           telemetry: Ai::TelemetrySettings,
-          delegated_auth: T.untyped
+          delegated_auth: T.nilable(T.anything)
         )
         .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
@@ -92,7 +92,7 @@ module Ai
 
     private
 
-    sig { params(delegated_auth: T.untyped).returns(T.nilable(String)) }
+    sig { params(delegated_auth: T.nilable(T.anything)).returns(T.nilable(String)) }
     def resolve_delegated_token(delegated_auth)
       return nil if delegated_auth.nil?
 

--- a/lib/ai/client.rb
+++ b/lib/ai/client.rb
@@ -32,15 +32,16 @@ module Ai
         .params(
           agent_name: String,
           messages: T::Array[Ai::Message],
-          options: T::Hash[Symbol, T.anything]
+          options: T::Hash[Symbol, T.anything],
+          delegated_token: T.nilable(String)
         )
         .returns(T::Hash[String, T.anything])
     end
-    def generate(agent_name, messages:, options: {})
+    def generate(agent_name, messages:, options: {}, delegated_token: nil)
     end
 
-    sig { abstract.params(workflow_name: String, input: T::Struct).returns(ApiResponse) }
-    def run_workflow(workflow_name, input:)
+    sig { abstract.params(workflow_name: String, input: T::Struct, delegated_token: T.nilable(String)).returns(ApiResponse) }
+    def run_workflow(workflow_name, input:, delegated_token: nil)
     end
 
     sig { abstract.params(workflow_name: String).returns(SchemaHash) }

--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -60,13 +60,14 @@ module Ai
           .params(
             agent_name: String,
             messages: T::Array[Ai::Message],
-            options: T::Hash[Symbol, T.anything]
+            options: T::Hash[Symbol, T.anything],
+            delegated_token: T.nilable(String)
           )
           .returns(T::Hash[String, T.anything])
       end
-      def generate(agent_name, messages:, options: {})
+      def generate(agent_name, messages:, options: {}, delegated_token: nil)
         url = URI.join(@base_uri, "api/agents/#{agent_name}/generate")
-        generated_response = response(url: url, messages: messages, options: options)
+        generated_response = response(url: url, messages: messages, options: options, delegated_token: delegated_token)
 
         parsed_response =
           JSON.parse(generated_response.body || '').deep_transform_keys(&:underscore)
@@ -83,15 +84,15 @@ module Ai
       end
 
       sig do
-        override.params(workflow_name: String, input: T::Struct).returns(Ai::Client::ApiResponse)
+        override.params(workflow_name: String, input: T::Struct, delegated_token: T.nilable(String)).returns(Ai::Client::ApiResponse)
       end
-      def run_workflow(workflow_name, input:)
+      def run_workflow(workflow_name, input:, delegated_token: nil)
         run_id = SecureRandom.uuid
 
         # Step 1: Create a new run for the workflow
         create_url =
           URI.join(@base_uri, "api/workflows/#{workflow_name}/create-run?runId=#{run_id}")
-        create_response = http_post(create_url, body: '{}')
+        create_response = http_post(create_url, body: '{}', delegated_token: delegated_token)
 
         unless create_response.is_a?(Net::HTTPSuccess)
           raise Ai::Error, "Mastra error – could not create workflow run: #{create_response.body}"
@@ -104,7 +105,7 @@ module Ai
         stream_error_body = T.let(nil, T.nilable(String))
         stream_body_chunks = T.let([], T::Array[String])
         stream_response =
-          http_post(stream_url, body: stream_request_body, stream: true) do |response|
+          http_post(stream_url, body: stream_request_body, stream: true, delegated_token: delegated_token) do |response|
             if response.is_a?(Net::HTTPSuccess)
               response.read_body do |chunk|
                 # Capture the stream body to check for workflow failures
@@ -144,6 +145,7 @@ module Ai
             .config
             .api_key
             .present?
+          result_request['X-Factorial-Delegated-Bearer'] = delegated_token if delegated_token.present?
           http = build_http
           result_response = http.request(result_request)
 
@@ -244,13 +246,15 @@ module Ai
           url: URI::Generic,
           body: T.nilable(String),
           stream: T::Boolean,
+          delegated_token: T.nilable(String),
           blk: T.nilable(T.proc.params(response: Net::HTTPResponse).void)
         ).returns(Net::HTTPResponse)
       end
-      def http_post(url, body: nil, stream: false, &blk)
+      def http_post(url, body: nil, stream: false, delegated_token: nil, &blk)
         request = Net::HTTP::Post.new(url)
         request['Origin'] = Ai.config.origin
         request['Authorization'] = "Bearer #{Ai.config.api_key}" if Ai.config.api_key.present?
+        request['X-Factorial-Delegated-Bearer'] = delegated_token if delegated_token.present?
         if body
           request['Content-Type'] = 'application/json'
           request.body = body
@@ -282,14 +286,16 @@ module Ai
         params(
           url: URI::Generic,
           messages: T::Array[Ai::Message],
-          options: T::Hash[Symbol, T.anything]
+          options: T::Hash[Symbol, T.anything],
+          delegated_token: T.nilable(String)
         ).returns(Net::HTTPResponse)
       end
-      def response(url:, messages:, options:)
+      def response(url:, messages:, options:, delegated_token: nil)
         request = Net::HTTP::Post.new(url)
         request['Content-Type'] = 'application/json'
         request['Origin'] = Ai.config.origin
         request['Authorization'] = "Bearer #{Ai.config.api_key}" if Ai.config.api_key.present?
+        request['X-Factorial-Delegated-Bearer'] = delegated_token if delegated_token.present?
 
         # convert to camelCase and unpacking for API compatibility
         camelized_options = deep_camelize_keys(options)

--- a/lib/ai/clients/test.rb
+++ b/lib/ai/clients/test.rb
@@ -30,11 +30,12 @@ module Ai
           .params(
             agent_name: String,
             messages: T::Array[Ai::Message],
-            options: T::Hash[Symbol, T.anything]
+            options: T::Hash[Symbol, T.anything],
+            delegated_token: T.nilable(String)
           )
           .returns(T::Hash[String, T.anything])
       end
-      def generate(agent_name, messages:, options: {})
+      def generate(agent_name, messages:, options: {}, delegated_token: nil)
         output = options[:structured_output]
 
         # Use the first message content for testing purposes
@@ -101,9 +102,9 @@ module Ai
       end
 
       sig do
-        override.params(workflow_name: String, input: T::Struct).returns(Ai::Client::ApiResponse)
+        override.params(workflow_name: String, input: T::Struct, delegated_token: T.nilable(String)).returns(Ai::Client::ApiResponse)
       end
-      def run_workflow(workflow_name, input:)
+      def run_workflow(workflow_name, input:, delegated_token: nil)
         @returned_object
       end
 

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Ai::Agent do
           max_retries: 2,
           max_steps: 5,
           telemetry: anything
-        }
+        },
+        delegated_token: nil
       ).and_call_original
 
       agent.generate_text(messages: [Ai.user_message('Hello')], runtime_context: runtime_context)
@@ -44,7 +45,8 @@ RSpec.describe Ai::Agent do
           max_retries: 5,
           max_steps: 10,
           telemetry: anything
-        }
+        },
+        delegated_token: nil
       ).and_call_original
 
       agent.generate_text(messages: [Ai.user_message('Hello')], max_retries: 5, max_steps: 10)
@@ -71,7 +73,8 @@ RSpec.describe Ai::Agent do
           max_retries: 2,
           max_steps: 5,
           telemetry: telemetry_settings
-        }
+        },
+        delegated_token: nil
       ).and_call_original
 
       agent.generate_text(messages: [Ai.user_message('Hello')], telemetry: telemetry_settings)
@@ -87,7 +90,8 @@ RSpec.describe Ai::Agent do
           max_retries: 2,
           max_steps: 5,
           telemetry: kind_of(Ai::TelemetrySettings)
-        }
+        },
+        delegated_token: nil
       ).and_call_original
 
       result = agent.generate_text(messages: [Ai.user_message('Hello')])
@@ -110,6 +114,45 @@ RSpec.describe Ai::Agent do
       expect(result.tool_calls).to eq([])
       expect(result.tool_results).to eq([])
       expect(result.steps).to eq([])
+    end
+
+    describe 'delegated_auth' do
+      it 'resolves delegated_auth to a token via the configured resolver and passes it to the client' do
+        principal = double('Company')
+        Ai.delegated_token_resolver = ->(p) { "resolved-token-for-#{p.class.name}" }
+
+        expect(client).to receive(:generate).with(
+          'test',
+          messages: anything,
+          options: anything,
+          delegated_token: 'resolved-token-for-RSpec::Mocks::Double'
+        ).and_call_original
+
+        agent.generate_text(messages: [Ai.user_message('Hello')], delegated_auth: principal)
+      end
+
+      it 'passes nil delegated_token when delegated_auth is nil' do
+        Ai.delegated_token_resolver = ->(_p) { raise 'should not be called' }
+
+        expect(client).to receive(:generate).with(
+          'test',
+          messages: anything,
+          options: anything,
+          delegated_token: nil
+        ).and_call_original
+
+        agent.generate_text(messages: [Ai.user_message('Hello')])
+      end
+
+      it 'raises Ai::Error when resolver is not configured but delegated_auth is provided' do
+        Ai.delegated_token_resolver = nil
+
+        expect {
+          agent.generate_text(messages: [Ai.user_message('Hello')], delegated_auth: double('Access'))
+        }.to raise_error(Ai::Error, /delegated_token_resolver is not configured/)
+      end
+
+      after { Ai.delegated_token_resolver = nil }
     end
   end
 
@@ -153,7 +196,8 @@ RSpec.describe Ai::Agent do
             max_steps: 8,
             structured_output: hash_including(schema: anything),
             telemetry: anything
-          )
+          ),
+        delegated_token: nil
       ).and_call_original
 
       agent.generate_object(
@@ -184,7 +228,8 @@ RSpec.describe Ai::Agent do
           hash_including(
             telemetry: telemetry_settings,
             structured_output: hash_including(schema: anything)
-          )
+          ),
+        delegated_token: nil
       ).and_call_original
 
       agent.generate_object(
@@ -216,6 +261,37 @@ RSpec.describe Ai::Agent do
       it 'handles type coercion correctly' do
         expect { subject }.to raise_error(ArgumentError)
       end
+    end
+
+    describe 'delegated_auth' do
+      before { client.set_returned_object({ 'name' => 'John Doe', 'age' => 30 }) }
+
+      let(:schema) do
+        Class.new(T::Struct) do
+          const :name, String
+          const :age, Integer
+        end
+      end
+
+      it 'resolves delegated_auth and passes delegated_token to the client' do
+        principal = double('Company')
+        Ai.delegated_token_resolver = ->(_p) { 'company-token-abc' }
+
+        expect(client).to receive(:generate).with(
+          'test',
+          messages: anything,
+          options: anything,
+          delegated_token: 'company-token-abc'
+        ).and_call_original
+
+        agent.generate_object(
+          messages: [Ai.user_message('Create person')],
+          output_class: schema,
+          delegated_auth: principal
+        )
+      end
+
+      after { Ai.delegated_token_resolver = nil }
     end
   end
 end

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -117,15 +117,17 @@ RSpec.describe Ai::Agent do
     end
 
     describe 'delegated_auth' do
+      after { Ai.delegated_token_resolver = nil }
+
       it 'resolves delegated_auth to a token via the configured resolver and passes it to the client' do
-        principal = double('Company')
+        principal = instance_double(Object)
         Ai.delegated_token_resolver = ->(p) { "resolved-token-for-#{p.class.name}" }
 
         expect(client).to receive(:generate).with(
           'test',
           messages: anything,
           options: anything,
-          delegated_token: 'resolved-token-for-RSpec::Mocks::Double'
+          delegated_token: "resolved-token-for-#{principal.class.name}"
         ).and_call_original
 
         agent.generate_text(messages: [Ai.user_message('Hello')], delegated_auth: principal)
@@ -147,12 +149,10 @@ RSpec.describe Ai::Agent do
       it 'raises Ai::Error when resolver is not configured but delegated_auth is provided' do
         Ai.delegated_token_resolver = nil
 
-        expect {
-          agent.generate_text(messages: [Ai.user_message('Hello')], delegated_auth: double('Access'))
-        }.to raise_error(Ai::Error, /delegated_token_resolver is not configured/)
+        expect do
+          agent.generate_text(messages: [Ai.user_message('Hello')], delegated_auth: instance_double(Object))
+        end.to raise_error(Ai::Error, /delegated_token_resolver is not configured/)
       end
-
-      after { Ai.delegated_token_resolver = nil }
     end
   end
 
@@ -264,6 +264,8 @@ RSpec.describe Ai::Agent do
     end
 
     describe 'delegated_auth' do
+      after { Ai.delegated_token_resolver = nil }
+
       before { client.set_returned_object({ 'name' => 'John Doe', 'age' => 30 }) }
 
       let(:schema) do
@@ -274,7 +276,7 @@ RSpec.describe Ai::Agent do
       end
 
       it 'resolves delegated_auth and passes delegated_token to the client' do
-        principal = double('Company')
+        principal = instance_double(Object)
         Ai.delegated_token_resolver = ->(_p) { 'company-token-abc' }
 
         expect(client).to receive(:generate).with(
@@ -290,8 +292,6 @@ RSpec.describe Ai::Agent do
           delegated_auth: principal
         )
       end
-
-      after { Ai.delegated_token_resolver = nil }
     end
   end
 end

--- a/spec/lib/ai/mastra_client_spec.rb
+++ b/spec/lib/ai/mastra_client_spec.rb
@@ -123,6 +123,51 @@ RSpec.describe Ai::Clients::Mastra do
 
       expect(stub).to have_been_requested
     end
+
+    it 'sends X-Factorial-Delegated-Bearer header when delegated_token is provided' do
+      delegated_token = 'delegated-jwt-token-abc123'
+
+      stub =
+        stub_request(:post, 'https://mastra.local.factorial.dev/api/agents/marvin/generate')
+          .with do |req|
+            req.headers['X-Factorial-Delegated-Bearer'] == delegated_token
+          end
+          .to_return(
+            status: 200,
+            body: { text: 'Test response' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+      client.generate(
+        'marvin',
+        messages: [Ai.user_message('test')],
+        options: {},
+        delegated_token: delegated_token
+      )
+
+      expect(stub).to have_been_requested
+    end
+
+    it 'does not send X-Factorial-Delegated-Bearer header when delegated_token is not provided' do
+      stub =
+        stub_request(:post, 'https://mastra.local.factorial.dev/api/agents/marvin/generate')
+          .with do |req|
+            !req.headers.key?('X-Factorial-Delegated-Bearer')
+          end
+          .to_return(
+            status: 200,
+            body: { text: 'Test response' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+      client.generate(
+        'marvin',
+        messages: [Ai.user_message('test')],
+        options: {}
+      )
+
+      expect(stub).to have_been_requested
+    end
   end
 
   describe '#run_workflow' do
@@ -143,6 +188,40 @@ RSpec.describe Ai::Clients::Mastra do
 
         expect(result).to eq('sumOfNumbers' => 8)
       end
+    end
+
+    it 'sends X-Factorial-Delegated-Bearer header on all requests when delegated_token is provided' do
+      delegated_token = 'delegated-jwt-token-workflow'
+
+      input = Class.new(T::Struct) { const :value, Integer }.new(value: 1)
+
+      # Stub create-run
+      create_stub =
+        stub_request(:post, %r{mastra\.local\.factorial\.dev/api/workflows/#{workflow_name}/create-run})
+          .with { |req| req.headers['X-Factorial-Delegated-Bearer'] == delegated_token }
+          .to_return(status: 200, body: '{}')
+
+      # Stub stream
+      stream_stub =
+        stub_request(:post, %r{mastra\.local\.factorial\.dev/api/workflows/#{workflow_name}/stream})
+          .with { |req| req.headers['X-Factorial-Delegated-Bearer'] == delegated_token }
+          .to_return(status: 200, body: '{"workflowStatus":"success"}')
+
+      # Stub result fetch
+      result_stub =
+        stub_request(:get, %r{mastra\.local\.factorial\.dev/api/workflows/#{workflow_name}/runs/})
+          .with { |req| req.headers['X-Factorial-Delegated-Bearer'] == delegated_token }
+          .to_return(
+            status: 200,
+            body: { status: 'success', result: { output: 'done' } }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+      client.run_workflow(workflow_name, input: input, delegated_token: delegated_token)
+
+      expect(create_stub).to have_been_requested
+      expect(stream_stub).to have_been_requested
+      expect(result_stub).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
## 🚪 Why?

Mastra agents need to authenticate with the Factorial backend when triggered by backend events (no user session). This PR adds the full delegated auth chain to `ruby-ai-client`: forwarding tokens to Mastra via HTTP headers, and a `delegated_auth:` parameter on `Ai::Agent` that resolves principals (Access or Company) to tokens through a configurable callback — so callers just pass the principal without manually minting tokens.

## 🔑 What?

**Token forwarding:**
- `Ai::Client` base class, `Ai::Clients::Mastra`, and `Ai::Clients::Test` accept an optional `delegated_token:` keyword on `generate` and `run_workflow`.
- `Mastra` client forwards it as `X-Factorial-Delegated-Bearer` HTTP header on all requests (agent generate, workflow create-run, stream, and result-fetch).
- Tests verify the header is sent when token is provided and absent when not.

**Principal-based resolver:**
- New `Ai.delegated_token_resolver` config accessor — the host application sets a lambda that resolves a principal (e.g. Access, Company) to a token string.
- `Ai::Agent#generate_text` and `#generate_object` accept `delegated_auth:` (any principal). Internally calls the resolver to get the token, then passes it to the client layer.
- `delegated_auth: nil` (the default) skips resolution entirely — agents that don't need backend auth work unchanged.
- Raises `Ai::Error` if `delegated_auth:` is provided but no resolver is configured.
- Full test coverage: resolver integration, nil passthrough, missing-resolver error.

## 📐 New interfaces

### `Ai::Agent#generate_text` / `#generate_object` — new `delegated_auth:` parameter

Pass an Access or Company principal to authenticate Mastra's downstream calls to the backend. The agent resolves it to a Doorkeeper token internally via the configured resolver. Optional — agents that don't call the backend omit it.

```ruby
# With Company auth (background jobs, Sidekiq — no user session)
agent.generate_object(messages: msgs, output_class: MyResult, delegated_auth: company)

# With Access auth (user-initiated flows)
agent.generate_text(messages: msgs, delegated_auth: access)

# No auth needed (unchanged) — agents that don't call the backend
agent.generate_text(messages: msgs)
```

### `Ai.delegated_token_resolver` — new config accessor

The host application configures a lambda that maps a principal to a token string. Set once in an initializer:

```ruby
# config/initializers/ai_client.rb
Ai.delegated_token_resolver = lambda { |principal|
  outcome =
    case principal
    when Access
      ApiCore::AccessInteractor::GenerateMastraDelegationToken.new(access: principal).call
    when Company
      ApiCore::CompanyInteractor::GenerateMastraDelegationToken.new(company: principal).call
    else
      raise Ai::Error, "Unsupported delegated auth principal: #{principal.class}"
    end

  raise Ai::Error, "Failed to mint delegated token" unless outcome.successful?
  outcome.value.token
}
```

### `Ai::Client#generate` / `#run_workflow` — new `delegated_token:` parameter (internal)

The client layer accepts a raw token string and the Mastra client forwards it as the `X-Factorial-Delegated-Bearer` HTTP header. This is internal plumbing — callers should use `Ai::Agent` with `delegated_auth:` instead.

```ruby
# Internal transport — not intended for direct use by callers
client.generate(agent_name, messages: msgs, options: opts, delegated_token: 'token-string')
client.run_workflow(workflow_name, input: input, delegated_token: 'token-string')
```

## 🏡 Context

- [📖 RFC: Mastra's auth on backend trigger](https://www.notion.so/factorialco/RFC-Mastra-s-auth-on-backend-trigger-3275e6e051ee809188b7e012a2bdf34f)