### PR TITLE
fix: rename runtime_context to request_context to match Mastra body schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai (0.5.3)
+    ai (0.6.0)
       actionpack (>= 7.1.3)
       activesupport (>= 7.1.3)
       json_schemer (~> 2.4.0)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ agent = Ai::Agent.new(agent_name: 'my_agent', client: Ai::Client.new)
 result = agent.generate_object(
   messages: messages,
   output_class: Output,
-  runtime_context: { user_id: 123, session: 'abc' },  # Optional context
+  request_context: { user_id: 123, session: 'abc' },  # Optional context
   max_retries: 3,                                     # Retry attempts (default: 2)
   max_steps: 10                                       # Max processing steps (default: 5)
 )
@@ -189,7 +189,7 @@ agent = Ai::Agent.new(agent_name: 'my_agent', client: Ai::Client.new)
 
 result = agent.generate_text(
   messages: messages,
-  runtime_context: {},  # Optional context
+  request_context: {},  # Optional context
   max_retries: 2,       # Retry attempts (default: 2)
   max_steps: 5          # Max processing steps (default: 5)
 )

--- a/bin/console
+++ b/bin/console
@@ -33,16 +33,16 @@ class MyAiMagicProcess
     sig do
       params(
         message: Ai::Message,
-        runtime_context: T::Hash[String, T.anything],
+        request_context: T::Hash[String, T.anything],
         max_retries: Integer,
         max_steps: Integer
       ).returns(Ai::GenerateTextResult)
     end
-    def self.generate_text(message:, runtime_context: {}, max_retries: 2, max_steps: 5)
+    def self.generate_text(message:, request_context: {}, max_retries: 2, max_steps: 5)
       Ai::Agent.generate_text(
         agent_name,
         message: message,
-        runtime_context: runtime_context,
+        request_context: request_context,
         max_retries: max_retries,
         max_steps: max_steps
       )
@@ -57,10 +57,10 @@ class MyAiMagicProcess
   def call
     message = Ai.user_message('hello')
 
-    response = MyAgent[Output].generate_object(message: message, runtime_context: {})
+    response = MyAgent[Output].generate_object(message: message, request_context: {})
     response.object.response
 
-    other_response = MyAgent.generate_text(message: message, runtime_context: {})
+    other_response = MyAgent.generate_text(message: message, request_context: {})
     other_response.text
   end
 end

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -19,7 +19,7 @@ module Ai
     sig do
       params(
         messages: T::Array[Ai::Message],
-        runtime_context: T::Hash[String, T.anything],
+        request_context: T::Hash[String, T.anything],
         max_retries: Integer,
         max_steps: Integer,
         telemetry: Ai::TelemetrySettings
@@ -27,13 +27,13 @@ module Ai
     end
     def generate_text(
       messages:,
-      runtime_context: {},
+      request_context: {},
       max_retries: 2,
       max_steps: 5,
       telemetry: Ai::TelemetrySettings.new
     )
       options = {
-        runtime_context: runtime_context,
+        request_context: request_context,
         max_retries: max_retries,
         max_steps: max_steps,
         telemetry: telemetry
@@ -48,7 +48,7 @@ module Ai
         .params(
           messages: T::Array[Ai::Message],
           output_class: T.all(T::Class[T.type_parameter(:O)], T::Class[T::Struct]),
-          runtime_context: T::Hash[String, T.anything],
+          request_context: T::Hash[String, T.anything],
           max_retries: Integer,
           max_steps: Integer,
           telemetry: Ai::TelemetrySettings
@@ -58,7 +58,7 @@ module Ai
     def generate_object(
       messages:,
       output_class:,
-      runtime_context: {},
+      request_context: {},
       max_retries: 2,
       max_steps: 5,
       telemetry: Ai::TelemetrySettings.new
@@ -66,7 +66,7 @@ module Ai
       schema = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
 
       options = {
-        runtime_context: runtime_context,
+        request_context: request_context,
         max_retries: max_retries,
         max_steps: max_steps,
         structured_output: {

--- a/lib/ai/version.rb
+++ b/lib/ai/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Ai
-  VERSION = '0.5.3'
+  VERSION = '0.6.0'
 end

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -17,21 +17,21 @@ RSpec.describe Ai::Agent do
       expect(result.usage.total_tokens).to eq(11)
     end
 
-    it 'passes runtime_context to the client' do
-      runtime_context = { 'user_id' => '123', 'session_id' => 'abc' }
+    it 'passes request_context to the client' do
+      request_context = { 'user_id' => '123', 'session_id' => 'abc' }
 
       expect(client).to receive(:generate).with(
         'test',
         messages: anything,
         options: {
-          runtime_context: runtime_context,
+          request_context: request_context,
           max_retries: 2,
           max_steps: 5,
           telemetry: anything
         }
       ).and_call_original
 
-      agent.generate_text(messages: [Ai.user_message('Hello')], runtime_context: runtime_context)
+      agent.generate_text(messages: [Ai.user_message('Hello')], request_context: request_context)
     end
 
     it 'passes custom max_retries and max_steps to client' do
@@ -39,7 +39,7 @@ RSpec.describe Ai::Agent do
         'test',
         messages: anything,
         options: {
-          runtime_context: {
+          request_context: {
           },
           max_retries: 5,
           max_steps: 10,
@@ -66,7 +66,7 @@ RSpec.describe Ai::Agent do
         'test',
         messages: anything,
         options: {
-          runtime_context: {
+          request_context: {
           },
           max_retries: 2,
           max_steps: 5,
@@ -82,7 +82,7 @@ RSpec.describe Ai::Agent do
         'test',
         messages: anything,
         options: {
-          runtime_context: {
+          request_context: {
           },
           max_retries: 2,
           max_steps: 5,
@@ -140,15 +140,15 @@ RSpec.describe Ai::Agent do
       expect(result.usage.cached_input_tokens).to be_nil
     end
 
-    it 'passes runtime_context and options to client' do
-      runtime_context = { 'user_id' => '456', 'context' => 'test' }
+    it 'passes request_context and options to client' do
+      request_context = { 'user_id' => '456', 'context' => 'test' }
 
       expect(client).to receive(:generate).with(
         'test',
         messages: anything,
         options:
           hash_including(
-            runtime_context: runtime_context,
+            request_context: request_context,
             max_retries: 3,
             max_steps: 8,
             structured_output: hash_including(schema: anything),
@@ -159,7 +159,7 @@ RSpec.describe Ai::Agent do
       agent.generate_object(
         messages: [Ai.user_message('Create person')],
         output_class: schema,
-        runtime_context: runtime_context,
+        request_context: request_context,
         max_retries: 3,
         max_steps: 8
       )


### PR DESCRIPTION
## Summary

Mastra's `POST /agents/:agentId/generate` handler reads **`requestContext`** from the request body. The gem was emitting `runtime_context:` on the options hash; `deep_camelize_keys` rewrote that to `runtimeContext` on the wire, which Mastra's schema does not recognize — the value was silently dropped. Every caller using dynamic instructions was therefore seeing `requestContext.get(key)` return `undefined` and falling back to defaults.

Concrete symptoms we hit in `factorialco/factorial` before tracking this down:

- OCR financial-document agent: `categoryHierarchy` and `currentDate` never arrived, so the model saw an empty `{}` hierarchy and never picked a category.
- `FinanceExpensesPolicyCompliance` + `FinanceExpensesExpenseApprovalRecommendation`: `language` never arrived, output always in English regardless of company locale.
- `TalentEngagementMeetingsAiSummary` + `TalentEngagementMeetingsContextGenerator`: `language` never arrived; `template_type` also never arrived (separate TS-side fix because of nested camelization — out of scope here).

## Origin of the bug

This gem's first commit landed on **2025-06-10** using `runtime_context:`, which matched the then-current Mastra API (`RuntimeContext`).

Upstream Mastra renamed the type in [mastra-ai/mastra#9511 "Rename RuntimeContext to RequestContext"](https://github.com/mastra-ai/mastra/pull/9511), merged **2025-10-30**, and shipped it as a breaking change in `@mastra/core@1.0.0` (see the `1.0.0` "Major Changes" section of [`packages/core/CHANGELOG.md`](https://github.com/mastra-ai/mastra/blob/main/packages/core/CHANGELOG.md)). On the server side the `/agents/:agentId/generate` handler was changed to read `requestContext` from the body (`agentExecutionBodySchema` only declares `requestContext`; `runtimeContext` is unknown and falls into `...rest`, which `agent.generate` does not consume).

The gem hadn't been updated in the meantime — we were on `0.5.3` still emitting `runtimeContext`. Since Mastra's Zod schema uses `.passthrough()`, the unknown key survived validation and was silently dropped by the handler, so no error surfaced and no logs flagged it. The failure mode was "dynamic instructions fall back to defaults on every request", which is very easy to miss when those defaults produce plausible output (English summaries, empty category hierarchy → "other", etc.).

`factorialco/factorial-agent` is already running `@mastra/core@1.4.0`, so the mismatch has been live for the full life of every `runtime_context:` caller in production.

## Change

Rename the public kwarg on `Ai::Agent#generate_text` and `Ai::Agent#generate_object` from `runtime_context:` to `request_context:`, and rename the options-hash key so `deep_camelize_keys` emits `requestContext` — the key Mastra actually reads.

Files touched:
- `lib/ai/agent.rb` — the rename itself.
- `spec/lib/ai/agent_spec.rb` — matching spec updates.
- `bin/console` + `README.md` — example code.
- `lib/ai/version.rb` — bumped to `0.6.0` (API rename is a breaking change for callers of this gem).

## Caller migration

Anywhere that passes `runtime_context:` must now pass `request_context:`. In `factorialco/factorial` this was five call sites:

- `ocr/.../factorial_agent/ocr_client.rb`
- `expenses/.../generate_policy_flags.rb`
- `expenses/.../generate_approval_recommendation.rb`
- `meetings/.../ai_summary/generator.rb`
- `meetings/.../context/generator.rb`

Those will be updated in a matching PR against that repo.

## Test plan

- [x] `bundle exec rspec` — 83 examples, 0 failures.
- [x] Manually verified against the backend: after `bundle update ai` and restarting Mastra, dynamic instructions are now receiving their context (hierarchy / language / template type / etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)