### PR TITLE
fix: camelize JSON-schema `required` values for OpenAI strict structured outputs

### DIFF
--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -236,7 +236,26 @@ module Ai
       sig { params(options: T::Hash[Symbol, T.anything]).returns(T::Hash[Symbol, T.anything]) }
       def deep_camelize_keys(options)
         json_options = JSON.parse(options.to_json)
-        json_options.deep_transform_keys { |key| key.to_s.camelize(:lower).to_sym }
+        camelized = json_options.deep_transform_keys { |key| key.to_s.camelize(:lower).to_sym }
+        # `deep_transform_keys` camelizes hash KEYS but not the string VALUES held
+        # in JSON-schema `required` arrays. That leaves `properties` in camelCase
+        # while `required` stays snake_case — a mismatch OpenAI's strict structured
+        # outputs reject ("`required` ... must be an array including every key in
+        # properties"). Align every `required` array with the camelized keys.
+        camelize_schema_required!(camelized)
+        camelized
+      end
+
+      sig { params(node: T.anything).void }
+      def camelize_schema_required!(node)
+        case node
+        when Hash
+          required = node[:required]
+          node[:required] = required.map { |key| key.to_s.camelize(:lower) } if required.is_a?(Array)
+          node.each_value { |value| camelize_schema_required!(value) }
+        when Array
+          node.each { |value| camelize_schema_required!(value) }
+        end
       end
 
       sig do

--- a/lib/ai/version.rb
+++ b/lib/ai/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Ai
-  VERSION = '0.6.1'
+  VERSION = '0.6.0'
 end

--- a/lib/ai/version.rb
+++ b/lib/ai/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Ai
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/lib/ai/mastra_client_spec.rb
+++ b/spec/lib/ai/mastra_client_spec.rb
@@ -125,6 +125,95 @@ RSpec.describe Ai::Clients::Mastra do
     end
   end
 
+  describe '#deep_camelize_keys' do
+    # Regression: `deep_camelize_keys` used to camelize property KEYS but leave the
+    # string VALUES in JSON-schema `required` arrays snake_case, producing a schema
+    # that OpenAI's strict structured outputs reject. `required` must list every key
+    # in `properties`, so it has to be camelized alongside them.
+
+    it 'camelizes `required` values to match the camelized property keys (flat)' do
+      options = {
+        structured_output: {
+          schema: {
+            type: 'object',
+            properties: {
+              matches: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    transaction_id: { type: 'integer' },
+                    category_id: { 'anyOf' => [{ type: 'integer' }, { type: 'null' }] }
+                  },
+                  required: %w[transaction_id category_id],
+                  additionalProperties: false
+                }
+              }
+            },
+            required: ['matches'],
+            additionalProperties: false
+          }
+        }
+      }
+
+      items =
+        client.send(:deep_camelize_keys, options).dig(
+          :structuredOutput,
+          :schema,
+          :properties,
+          :matches,
+          :items
+        )
+
+      aggregate_failures do
+        expect(items[:properties].keys).to contain_exactly(:transactionId, :categoryId)
+        expect(items[:required]).to eq(%w[transactionId categoryId])
+      end
+    end
+
+    it 'camelizes `required` inside nested nilable (anyOf) schemas' do
+      options = {
+        structured_output: {
+          schema: {
+            type: 'object',
+            properties: {
+              payment_details: {
+                'anyOf' => [
+                  {
+                    type: 'object',
+                    properties: {
+                      account_number: { 'anyOf' => [{ type: 'string' }, { type: 'null' }] }
+                    },
+                    required: %w[account_number],
+                    additionalProperties: false
+                  },
+                  { type: 'null' }
+                ]
+              }
+            },
+            required: %w[payment_details],
+            additionalProperties: false
+          }
+        }
+      }
+
+      object_branch =
+        client.send(:deep_camelize_keys, options).dig(
+          :structuredOutput,
+          :schema,
+          :properties,
+          :paymentDetails,
+          :anyOf,
+          0
+        )
+
+      aggregate_failures do
+        expect(object_branch[:properties].keys).to contain_exactly(:accountNumber)
+        expect(object_branch[:required]).to eq(%w[accountNumber])
+      end
+    end
+  end
+
   describe '#run_workflow' do
     let(:workflow_name) { 'testWorkflow' }
     let(:input) do


### PR DESCRIPTION
## Problem

Since the Mastra SDK upgrade (`ai` 5→6, `@ai-sdk/azure` 2→3, `@mastra/core` 1.4→1.45), agents using structured outputs (`generate_object`) started failing in production with:

```
Ai::Error: Invalid schema for response_format 'response':
In context=('properties','matches','items'), 'required' is required to be supplied
and to be an array including every key in properties. Missing 'transactionId'.
```

This is firing across **many** structured-output agents at once — banking transaction categorization, the finance OCR document scanner, the interactive GraphQL path, performance-review summaries, and more (1,000+ events / 300+ users).

**Triggered by:** factorialco/factorial-agent#1826 ("MASTRA UPGRADE", merged 2026-07-01) — https://github.com/factorialco/factorial-agent/pull/1826 — which bumped `ai` 5→6 / `@ai-sdk/azure` 2→3 / `@mastra/core` 1.4→1.45, enabling OpenAI *strict* structured outputs. The largest wave (banking + OCR Sidekiq jobs and more) escalated right after its deploy today; the same schema signature also appears via the interactive GraphQL path going back ~6 days. Either way the upgrade did not introduce the bug — it exposed this latent one, and the root cause + fix are identical for all of them.

### Affected Sentry issues (same root cause)

[Dashboard — all `Invalid schema for response_format` errors](https://factorial.sentry.io/issues/?query=%22Invalid+schema+for+response_format%22). Every one has the same signature: `required` must include every key in `properties`; `Missing '<camelCaseField>'`.

- **Banking** — [BACKEND-5601](https://factorial.sentry.io/issues/BACKEND-5601) · `Missing 'transactionId'` · `Banking::Jobs::Transactions::Categorize`
- **OCR invoices** — [BACKEND-5602](https://factorial.sentry.io/issues/BACKEND-5602) / [BACKEND-53HX](https://factorial.sentry.io/issues/BACKEND-53HX) · `Missing 'accountNumber'` · `Finance::EventHandlers::Invoices::ProcessProcessing` — surfaced as [BACKEND-55W1](https://factorial.sentry.io/issues/BACKEND-55W1) "OCR agent is temporarily unavailable"
- **Interactive / GraphQL** (highest volume) — [BACKEND-4YS6](https://factorial.sentry.io/issues/BACKEND-4YS6) (781 events / 314 users), [BACKEND-4TJF](https://factorial.sentry.io/issues/BACKEND-4TJF), [BACKEND-55KS](https://factorial.sentry.io/issues/BACKEND-55KS), [BACKEND-5600](https://factorial.sentry.io/issues/BACKEND-5600) · `Missing 'accountNumber'` · `ApiPrivate::GraphqlController#execute`
- **Others** — [BACKEND-5604](https://factorial.sentry.io/issues/BACKEND-5604) `Missing 'performanceReviewSummary'`, [BACKEND-5605](https://factorial.sentry.io/issues/BACKEND-5605) `Missing 'lastMeetingContext'`

## Root cause (a latent bug, not the upgrade)

`Ai::StructToJsonSchema.convert` builds the schema from a `T::Struct` with snake_case keys in **both** `properties` and `required` — internally consistent.

`Ai::Clients::Mastra#deep_camelize_keys` then runs `deep_transform_keys`, which camelizes hash **KEYS** but not array string **VALUES**:

- `properties` keys → camelCase (`transaction_id` → `transactionId`) ✅
- `required` values → stay snake_case (`transaction_id`) ❌ (they are array elements, not keys)

So the schema sent to OpenAI has always been internally inconsistent (`properties` camelCase, `required` snake_case).

**Why it only breaks now:** the pre-upgrade path did not enforce OpenAI *strict* structured outputs, so the mismatch was tolerated. The upgraded SDK enables strict mode, where OpenAI requires `required` to list every property key by exact name. The camel/snake mismatch now fails validation. The upgrade did not introduce the bug — it exposed a latent one.

## Fix

After `deep_transform_keys`, recursively align every `required` array with the camelized property keys (`camelize_schema_required!`). The walk is recursive so it also handles **nested** and **nilable (`anyOf`)** structs — e.g. the OCR `payment_details.account_number` case (`context=('properties','paymentDetails','anyOf','0'), Missing 'accountNumber'`), not just flat top-level schemas.

## Verification

- Reproduced deterministically (no OpenAI call) using the real production struct through the exact path (`StructToJsonSchema.convert` → `deep_camelize_keys`):
  - before: `properties=[transactionId, categoryId]`, `required=[transaction_id, category_id]` → strict **REJECTS**
  - after: `required=[transactionId, categoryId]` → strict **ACCEPTS**
- Added two regression specs (flat + nested `anyOf`). Note the pre-existing "converts struct fields to camelCase" spec never asserted `required` — which is how this slipped through.
- `bundle exec rspec` → 85 examples, 0 failures · `srb tc` → no errors · `rubocop` → no offenses.

## Impact

Fixes structured-output failures across **all** agents whose struct has multi-word (snake_case) fields — banking categorization, finance OCR, etc. This is a cross-domain production incident; after merge + release, bump the `ai` gem pin in the monorepo `Gemfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
