### PR TITLE
chore: uncouple Sorbet version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'railties'
 gem 'json_schemer', '~> 2.4'
 gem 'sorbet', '0.5.12196'
 gem 'sorbet-coerce', '~> 0.7'
-gem 'sorbet-static-and-runtime', '0.5.12196'
 
 group :development, :test do
   gem 'rspec'
@@ -25,6 +24,7 @@ group :development, :test do
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.0'
   gem 'tapioca', '~> 0.17.7', require: false
+  gem 'sorbet-static-and-runtime', '0.5.12196'
   gem 'syntax_tree', '~> 6.2', require: false
   gem 'prettier', '~> 3.2.2'
   gem 'ruby_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    ai (0.6.0)
+    ai (0.6.1)
       actionpack (>= 7.1.3)
       activesupport (>= 7.1.3)
       json_schemer (~> 2.4.0)
       railties (>= 7.1.3)
       sorbet-coerce (~> 0.7)
-      sorbet-static-and-runtime (= 0.5.12196)
+      sorbet-runtime (>= 0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/ai.gemspec
+++ b/ai.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json_schemer', '~> 2.4.0'
   spec.add_dependency 'railties', '>= 7.1.3'
   spec.add_dependency 'sorbet-coerce', '~> 0.7'
-  spec.add_dependency 'sorbet-static-and-runtime', '0.5.12196'
+  spec.add_dependency 'sorbet-runtime', '>= 0.5'
 end


### PR DESCRIPTION

Right now, the Sorbet version defined in this gem and others forces the requiring project to use a certain Sorbet version. We relax this requirement so it stops bothering the users of this gem when trying to update Sorbet versions.
