### PR TITLE
feat: per-request headers on generate calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai (0.6.1)
+    ai (0.7.0)
       actionpack (>= 7.1.3)
       activesupport (>= 7.1.3)
       json_schemer (~> 2.4.0)

--- a/lib/ai/agent.rb
+++ b/lib/ai/agent.rb
@@ -22,7 +22,8 @@ module Ai
         request_context: T::Hash[String, T.anything],
         max_retries: Integer,
         max_steps: Integer,
-        telemetry: Ai::TelemetrySettings
+        telemetry: Ai::TelemetrySettings,
+        headers: T::Hash[String, String]
       ).returns(Ai::GenerateTextResult)
     end
     def generate_text(
@@ -30,7 +31,8 @@ module Ai
       request_context: {},
       max_retries: 2,
       max_steps: 5,
-      telemetry: Ai::TelemetrySettings.new
+      telemetry: Ai::TelemetrySettings.new,
+      headers: {}
     )
       options = {
         request_context: request_context,
@@ -39,7 +41,7 @@ module Ai
         telemetry: telemetry
       }
 
-      data = client.generate(agent_name, messages: messages, options: options)
+      data = client.generate(agent_name, messages: messages, options: options, headers: headers)
       TypeCoerce[Ai::GenerateTextResult].new.from(data, raise_coercion_error: false)
     end
 
@@ -51,7 +53,8 @@ module Ai
           request_context: T::Hash[String, T.anything],
           max_retries: Integer,
           max_steps: Integer,
-          telemetry: Ai::TelemetrySettings
+          telemetry: Ai::TelemetrySettings,
+          headers: T::Hash[String, String]
         )
         .returns(GenerateObjectResult[T.type_parameter(:O)])
     end
@@ -61,7 +64,8 @@ module Ai
       request_context: {},
       max_retries: 2,
       max_steps: 5,
-      telemetry: Ai::TelemetrySettings.new
+      telemetry: Ai::TelemetrySettings.new,
+      headers: {}
     )
       schema = Ai::StructToJsonSchema.convert(T.cast(output_class, T.class_of(T::Struct)))
 
@@ -75,7 +79,7 @@ module Ai
         telemetry: telemetry
       }
 
-      data = client.generate(agent_name, messages: messages, options: options)
+      data = client.generate(agent_name, messages: messages, options: options, headers: headers)
 
       object = TypeCoerce[output_class].from(data['object'])
       TypeCoerce[GenerateObjectResult]

--- a/lib/ai/client.rb
+++ b/lib/ai/client.rb
@@ -32,11 +32,12 @@ module Ai
         .params(
           agent_name: String,
           messages: T::Array[Ai::Message],
-          options: T::Hash[Symbol, T.anything]
+          options: T::Hash[Symbol, T.anything],
+          headers: T::Hash[String, String]
         )
         .returns(T::Hash[String, T.anything])
     end
-    def generate(agent_name, messages:, options: {})
+    def generate(agent_name, messages:, options: {}, headers: {})
     end
 
     sig { abstract.params(workflow_name: String, input: T::Struct).returns(ApiResponse) }

--- a/lib/ai/clients/mastra.rb
+++ b/lib/ai/clients/mastra.rb
@@ -60,13 +60,14 @@ module Ai
           .params(
             agent_name: String,
             messages: T::Array[Ai::Message],
-            options: T::Hash[Symbol, T.anything]
+            options: T::Hash[Symbol, T.anything],
+            headers: T::Hash[String, String]
           )
           .returns(T::Hash[String, T.anything])
       end
-      def generate(agent_name, messages:, options: {})
+      def generate(agent_name, messages:, options: {}, headers: {})
         url = URI.join(@base_uri, "api/agents/#{agent_name}/generate")
-        generated_response = response(url: url, messages: messages, options: options)
+        generated_response = response(url: url, messages: messages, options: options, headers: headers)
 
         parsed_response =
           JSON.parse(generated_response.body || '').deep_transform_keys(&:underscore)
@@ -301,14 +302,18 @@ module Ai
         params(
           url: URI::Generic,
           messages: T::Array[Ai::Message],
-          options: T::Hash[Symbol, T.anything]
+          options: T::Hash[Symbol, T.anything],
+          headers: T::Hash[String, String]
         ).returns(Net::HTTPResponse)
       end
-      def response(url:, messages:, options:)
+      def response(url:, messages:, options:, headers: {})
         request = Net::HTTP::Post.new(url)
         request['Content-Type'] = 'application/json'
         request['Origin'] = Ai.config.origin
         request['Authorization'] = "Bearer #{Ai.config.api_key}" if Ai.config.api_key.present?
+        # Per-request headers win over the global configuration (e.g. a
+        # service-to-service Authorization token replacing the shared api_key).
+        headers.each { |name, value| request[name] = value }
 
         # convert to camelCase and unpacking for API compatibility
         camelized_options = deep_camelize_keys(options)

--- a/lib/ai/clients/test.rb
+++ b/lib/ai/clients/test.rb
@@ -13,7 +13,12 @@ module Ai
       def initialize(endpoint = Ai.config.endpoint)
         @endpoint = endpoint
         @returned_object = T.let({}, Ai::Client::ApiResponse)
+        @last_headers = T.let({}, T::Hash[String, String])
       end
+
+      # Headers received by the most recent generate call, for test assertions.
+      sig { returns(T::Hash[String, String]) }
+      attr_reader :last_headers
 
       sig { override.returns(T::Array[String]) }
       def agent_names
@@ -30,11 +35,13 @@ module Ai
           .params(
             agent_name: String,
             messages: T::Array[Ai::Message],
-            options: T::Hash[Symbol, T.anything]
+            options: T::Hash[Symbol, T.anything],
+            headers: T::Hash[String, String]
           )
           .returns(T::Hash[String, T.anything])
       end
-      def generate(agent_name, messages:, options: {})
+      def generate(agent_name, messages:, options: {}, headers: {})
+        @last_headers = headers
         output = options[:structured_output]
 
         # Use the first message content for testing purposes

--- a/lib/ai/version.rb
+++ b/lib/ai/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Ai
-  VERSION = '0.6.1'
+  VERSION = '0.7.0'
 end

--- a/spec/lib/ai/agent_spec.rb
+++ b/spec/lib/ai/agent_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Ai::Agent do
 
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options: {
           request_context: request_context,
@@ -37,6 +38,7 @@ RSpec.describe Ai::Agent do
     it 'passes custom max_retries and max_steps to client' do
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options: {
           request_context: {
@@ -64,6 +66,7 @@ RSpec.describe Ai::Agent do
 
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options: {
           request_context: {
@@ -80,6 +83,7 @@ RSpec.describe Ai::Agent do
     it 'uses default telemetry settings when none provided' do
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options: {
           request_context: {
@@ -111,6 +115,24 @@ RSpec.describe Ai::Agent do
       expect(result.tool_results).to eq([])
       expect(result.steps).to eq([])
     end
+
+    it 'forwards per-request headers to the client' do
+      agent.generate_text(
+        messages: [Ai.user_message('Hello')],
+        headers: { 'X-Factorial-Actor-Type' => 'Employee', 'X-Factorial-Actor-Id' => '42' }
+      )
+
+      expect(client.last_headers).to eq(
+        'X-Factorial-Actor-Type' => 'Employee',
+        'X-Factorial-Actor-Id' => '42'
+      )
+    end
+
+    it 'sends no per-request headers by default' do
+      agent.generate_text(messages: [Ai.user_message('Hello')])
+
+      expect(client.last_headers).to eq({})
+    end
   end
 
   describe '#generate_object' do
@@ -140,11 +162,22 @@ RSpec.describe Ai::Agent do
       expect(result.usage.cached_input_tokens).to be_nil
     end
 
+    it 'forwards per-request headers to the client' do
+      agent.generate_object(
+        messages: [Ai.user_message('Create person')],
+        output_class: schema,
+        headers: { 'Authorization' => 'Bearer a-service-token' }
+      )
+
+      expect(client.last_headers).to eq('Authorization' => 'Bearer a-service-token')
+    end
+
     it 'passes request_context and options to client' do
       request_context = { 'user_id' => '456', 'context' => 'test' }
 
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options:
           hash_including(
@@ -179,6 +212,7 @@ RSpec.describe Ai::Agent do
 
       expect(client).to receive(:generate).with(
         'test',
+        headers: anything,
         messages: anything,
         options:
           hash_including(

--- a/spec/lib/ai/mastra_client_spec.rb
+++ b/spec/lib/ai/mastra_client_spec.rb
@@ -125,6 +125,60 @@ RSpec.describe Ai::Clients::Mastra do
     end
   end
 
+  describe '#generate with per-request headers' do
+    let(:generate_url) { "#{endpoint}/api/agents/marvin/generate" }
+
+    before do
+      Ai.config.api_key = 'global-api-key'
+      stub_request(:post, generate_url).to_return(
+        status: 200,
+        body: { text: 'Test response' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    after { Ai.config.api_key = nil }
+
+    it 'sends the given headers alongside the global ones' do
+      client.generate(
+        'marvin',
+        messages: [Ai.user_message('test')],
+        headers: {
+          'X-Factorial-Actor-Type' => 'Employee',
+          'X-Factorial-Actor-Id' => '42'
+        }
+      )
+
+      expect(WebMock).to have_requested(:post, generate_url).with(
+        headers: {
+          'Authorization' => 'Bearer global-api-key',
+          'X-Factorial-Actor-Type' => 'Employee',
+          'X-Factorial-Actor-Id' => '42'
+        }
+      )
+    end
+
+    it 'lets per-request headers override the global configuration' do
+      client.generate(
+        'marvin',
+        messages: [Ai.user_message('test')],
+        headers: { 'Authorization' => 'Bearer per-request-token' }
+      )
+
+      expect(WebMock).to have_requested(:post, generate_url).with(
+        headers: { 'Authorization' => 'Bearer per-request-token' }
+      )
+    end
+
+    it 'sends only the global headers by default' do
+      client.generate('marvin', messages: [Ai.user_message('test')])
+
+      expect(WebMock).to have_requested(:post, generate_url).with(
+        headers: { 'Authorization' => 'Bearer global-api-key' }
+      )
+    end
+  end
+
   describe '#deep_camelize_keys' do
     # Regression: `deep_camelize_keys` used to camelize property KEYS but leave the
     # string VALUES in JSON-schema `required` arrays snake_case, producing a schema


### PR DESCRIPTION
## Why
Factorial is moving backend↔factorial-agent auth from the shared `MASTRA_API_KEY` secret to factorial-id service tokens with actor attribution ([FCT-58575](https://factorialmakers.atlassian.net/browse/FCT-58575)). The caller needs to set per-request headers — an `Authorization` service token plus `X-Factorial-Actor-Type`/`X-Factorial-Actor-Id` — which the client can't do today: it only sends the process-wide `Ai.config.api_key`.

## What
- `Ai::Agent#generate_text` / `#generate_object` accept an optional `headers:` hash (default `{}`).
- `Ai::Client#generate` (abstract), `Ai::Clients::Mastra#generate` and `#response` thread it through; per-request headers are applied after the global `Origin`/`Authorization`, so they win on conflict.
- `Ai::Clients::Test` accepts the kwarg and exposes `last_headers` for assertions.
- Version bumped to 0.7.0.

## Consumer
factorialco/factorial#105401's `AiInteractions::AgentGateway` is the first caller — its pending end-to-end specs assert this exact header contract and flip green when the monorepo's Gemfile picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FCT-58575]: https://factorialmakers.atlassian.net/browse/FCT-58575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ